### PR TITLE
adding tls support via axum_server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = { version = "0.5.1", features = ["ws"] }
+axum-server = { version = "0.4.0", features = ["tls-rustls"] }
 base64 = "0.13.0"
 futures = "0.3.21"
 http = "0.2.6"

--- a/generate_self_signed_certs.sh
+++ b/generate_self_signed_certs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj "/CN=test" -nodes


### PR DESCRIPTION
I am trying to add tls support, but I get errors about "self signed certificate" from `websocat` and `curl` unless I use `-k` - however, I can't simply do `-k` when Twilio tries to connect. So I'm a bit stumped at how to test this - maybe I need a not-self-signed certificate, but if someone has a quick and dirty solution, that would be great.