### PR TITLE
removing generation script for self-signed certs

### DIFF
--- a/generate_self_signed_certs.sh
+++ b/generate_self_signed_certs.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj "/CN=test" -nodes


### PR DESCRIPTION
Twilio won't work with self-signed certs anyways.